### PR TITLE
Fix for newer versions of Riot.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function RiotStateRenderer(options) {
 				}
 
 				try {
-					var tag = riot.mount(element, template, xtend(defaultOpts, content))
+					var tag = riot.mount(element, template, xtend(defaultOpts, content))[0]
 
 					if (!tag) {
 						console.error('Error creating riot tag', template, 'on', element)


### PR DESCRIPTION
Hi! First of all, thank you for your work on abstract state router. Newer versions of riot.mount() return array of mounted tags, hence this little patch.
